### PR TITLE
Replace "hook-env" by "env" - and add auto install

### DIFF
--- a/mise.lua
+++ b/mise.lua
@@ -65,11 +65,12 @@ local function install()
     local config_output = config_check:read("*a")
     config_check:close()
 
-    -- Trim und prüfen auf leeren Inhalt
-    config_output = config_output:match("^%s*(.-)%s*$")  -- trim
+    -- trim
+    config_output = config_output:match("^%s*(.-)%s*$")
 
     if config_output == "" then
-        return  -- keine Config → nichts tun
+        -- nothing found -> no action needed
+        return
     end
 
     local hook_cmd = string.format('"%s" install', mise_path)


### PR DESCRIPTION
Two things:

1. Bug fix `hook-env` is now `env` (the latter worked for me)
2. Add support for `mise install`.

Drawback of 2: cmd gets a bit slower, but I like it... Not sure whether I should remove it or make it optional.

Maybe, we need a map storing the directories where the we know that `mise install` was executed.