### PR TITLE
feat(mise.ps1): remove `mise.cmd` directory from Path

### DIFF
--- a/mise.ps1
+++ b/mise.ps1
@@ -1,4 +1,5 @@
 ## If mise.cmd is in a PATH directory then, invoking 'mise' from Powershell will result in calling 'mise.cmd',
 ## which is only compatible with cmd + clink. Hence, this 'mise.ps1' is here to override that behaviour.
 
+$env:Path = $env:Path.Replace("$PSScriptRoot;", "")
 & mise.exe $args


### PR DESCRIPTION
- Even though it'd refer mise.ps1 in pwsh, I think it'd better to remove the directory.