### PR TITLE
feat: use mise clink config to store cached values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bin
 /*.usage.lua
+
+mise.clink.json


### PR DESCRIPTION
- This helps in reducing startup time when clink loads mise.lua.
- Also, moved auto activation into a coroutine block which further reduces startup time.